### PR TITLE
have portalv2 make requests to api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -396,6 +396,7 @@ lazy val portalv2JS = portalv2
     npmDependencies in Compile ++= portalv2NpmDependencies,
     webpackBundlingMode := BundlingMode.LibraryAndApplication() // needed to access JSExports from ScalaJSBundlerPlugin
   )
+  .dependsOn(core)
   .enablePlugins(ScalaJSBundlerPlugin)
 
 lazy val portalv2JVM = portalv2
@@ -405,6 +406,7 @@ lazy val portalv2JVM = portalv2
     (resources in Compile) += (webpack in fastOptJS in Compile in portalv2JS).value.head.data, // copy js files
     libraryDependencies ++= portalv2JvmDependencies.value
   )
+  .dependsOn(core)
 
 lazy val docSettings = Seq(
   git.remoteRepo := "https://github.com/vinyldns/vinyldns",

--- a/modules/portalv2/jvm/src/main/resources/reference.conf
+++ b/modules/portalv2/jvm/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+vinyldns-portal {
+  crypto {
+    type = "vinyldns.core.crypto.JavaCrypto"
+    secret = "8B06A7F3BC8A2497736F1916A123AA40E88217BE9264D8872597EF7A6E5DCE61"
+  }
+}

--- a/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylDNSApiClient.scala
+++ b/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylDNSApiClient.scala
@@ -1,0 +1,45 @@
+package vinyldns.portalv2JVM
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.RawHeader
+import com.amazonaws.auth.{BasicAWSCredentials, SignerFactory}
+import vinyldns.core.crypto.CryptoAlgebra
+import vinyldns.core.domain.membership.User
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+case class VinylDNSApiClient() {
+  implicit val system = ActorSystem()
+
+  def executeRequest(): Future[HttpResponse] = {
+    val user = User("testUser", "testUserAccessKey", "testUserSecretKey")
+    val crypto = CryptoAlgebra.load(VinylDNSPortalConfig.cryptoConfig).unsafeRunSync()
+    val request = VinylDNSRequest(
+      "GET",
+      "http://localhost:9000",
+      "/zones"
+    )
+    val signableRequest = new SignableVinylDNSRequest(request)
+    val credentials = new BasicAWSCredentials(user.accessKey, crypto.decrypt(user.secretKey))
+    val signer = SignerFactory.getSigner("VinylDNS", "us/east")
+
+    signer.sign(signableRequest, credentials)
+
+    val akkaRequest = fromSignableRequest(signableRequest)
+
+    Http().singleRequest(akkaRequest)
+  }
+
+  def fromSignableRequest(signableVinylDNSRequest: SignableVinylDNSRequest): HttpRequest = {
+    val headers = signableVinylDNSRequest.getHeaders.asScala
+      .map(h => RawHeader(h._1, h._2))
+      .toList
+    HttpRequest(
+      HttpMethods.GET,
+      signableVinylDNSRequest.getEndpoint + signableVinylDNSRequest.getResourcePath
+    ).withHeaders(headers)
+  }
+}

--- a/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylDNSPortalConfig.scala
+++ b/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylDNSPortalConfig.scala
@@ -1,0 +1,11 @@
+package vinyldns.portalv2JVM
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+object VinylDNSPortalConfig {
+
+  lazy val config: Config = ConfigFactory.load()
+  lazy val portalConfig: Config = config.getConfig("vinyldns-portal")
+
+  lazy val cryptoConfig: Config = portalConfig.getConfig("crypto")
+}

--- a/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylRequest.scala
+++ b/modules/portalv2/jvm/src/main/scala/vinyldns/portalv2JVM/VinylRequest.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.portalv2JVM
+
+import java.io.{ByteArrayInputStream, InputStream}
+import java.util
+
+import com.amazonaws.http.HttpMethodName
+import com.amazonaws.{ReadLimitInfo, SignableRequest}
+
+object VinylDNSRequest {
+  val APPLICATION_JSON = "application/json"
+}
+
+case class VinylDNSRequest(
+    method: String,
+    url: String,
+    path: String = "",
+    payload: Option[String] = None,
+    parameters: util.HashMap[String, java.util.List[String]] =
+      new util.HashMap[String, java.util.List[String]]())
+
+class SignableVinylDNSRequest(origReq: VinylDNSRequest) extends SignableRequest[VinylDNSRequest] {
+
+  import VinylDNSRequest._
+
+  val contentType: String = APPLICATION_JSON
+
+  private val headers = new util.HashMap[String, String]()
+  private val parameters = origReq.parameters
+  private val uri = new java.net.URI(origReq.url)
+  // I hate to do this, but need to be able to set the content after creation to
+  // implement the interface properly
+  private var contentStream: InputStream = new ByteArrayInputStream(
+    origReq.payload.getOrElse("").getBytes("UTF-8"))
+
+  override def addHeader(name: String, value: String): Unit = headers.put(name, value)
+  override def getHeaders: java.util.Map[String, String] = headers
+  override def getResourcePath: String = origReq.path
+  override def addParameter(name: String, value: String): Unit = {
+    if (!parameters.containsKey(name)) parameters.put(name, new util.ArrayList[String]())
+    parameters.get(name).add(value)
+  }
+  override def getParameters: java.util.Map[String, java.util.List[String]] = parameters
+  override def getEndpoint: java.net.URI = uri
+  override def getHttpMethod: HttpMethodName = HttpMethodName.valueOf(origReq.method)
+  override def getTimeOffset: Int = 0
+  override def getContent: InputStream = contentStream
+  override def getContentUnwrapped: InputStream = getContent
+  override def getReadLimitInfo: ReadLimitInfo = new ReadLimitInfo {
+    override def getReadLimit: Int = -1
+  }
+  override def getOriginalRequestObject: Object = origReq
+  override def setContent(content: InputStream): Unit = contentStream = content
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -115,27 +115,27 @@ object Dependencies {
 
   lazy val portalv2SharedDependencies = Def.setting(
     Seq(
-      "com.lihaoyi" %%% "scalatags" % "0.6.2",
-      "com.lihaoyi" %%% "upickle" % "0.4.4"
+      "com.lihaoyi"             %%% "scalatags"                     % "0.6.2",
+      "com.lihaoyi"             %%% "upickle"                       % "0.4.4"
     )
   )
 
   lazy val portalv2JsDependencies = Def.setting(
     Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.1",
-      "com.github.japgolly.scalajs-react" %%% "core" % scalaJSReactVersion,
-      "com.github.japgolly.scalajs-react" %%% "extra" % scalaJSReactVersion,
-      "com.github.japgolly.scalacss" %%% "core" % scalaCssVersion,
-      "com.github.japgolly.scalacss" %%% "ext-react" % scalaCssVersion
+      "org.scala-js"                      %%% "scalajs-dom"         % "0.9.1",
+      "com.github.japgolly.scalajs-react" %%% "core"                % scalaJSReactVersion,
+      "com.github.japgolly.scalajs-react" %%% "extra"               % scalaJSReactVersion,
+      "com.github.japgolly.scalacss"      %%% "core"                % scalaCssVersion,
+      "com.github.japgolly.scalacss"      %%% "ext-react"           % scalaCssVersion
     )
   )
 
   lazy val portalv2JvmDependencies = Def.setting(
     Seq(
-      "com.typesafe.akka" %% "akka-http" % "10.1.7",
-      "com.typesafe.akka" %% "akka-actor" % "2.5.19",
-      "com.typesafe.akka" %% "akka-stream" % "2.5.19",
-      "org.webjars" % "bootstrap" % "3.2.0"
+      "com.typesafe.akka"       %% "akka-http"                      % "10.1.7",
+      "com.typesafe.akka"       %% "akka-actor"                     % "2.5.19",
+      "com.typesafe.akka"       %% "akka-stream"                    % "2.5.19",
+      "com.amazonaws"           %  "aws-java-sdk-core"              % awsV withSources()
     )
   )
 


### PR DESCRIPTION
Changes in this pull request:

hitting the path `server` will execute a vinyldns api request and forward that to the client
