### PR TITLE
have portal module serve react

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ import scoverage.ScoverageKeys.{coverageFailOnMinimum, coverageMinimum}
 import org.scalafmt.sbt.ScalafmtPlugin._
 import microsites._
 import ReleaseTransformations._
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 resolvers ++= additionalResolvers
 
@@ -46,7 +47,7 @@ def scalaStyleSettings: Seq[Def.Setting[_]] = scalaStyleCompile ++ scalaStyleTes
 // settings that should be inherited by all projects
 lazy val sharedSettings = Seq(
   organization := "vinyldns",
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.8",
   organizationName := "Comcast Cable Communications Management, LLC",
   startYear := Some(2018),
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
@@ -231,7 +232,7 @@ lazy val root = (project in file(".")).enablePlugins(AutomateHeaderPlugin)
       "./bin/remove-vinyl-containers.sh" !
     },
   )
-  .aggregate(core, api, portal, dynamodb, mysql, sqs)
+  .aggregate(core, api, portal, dynamodb, mysql, sqs, v2client)
 
 lazy val coreBuildSettings = Seq(
   name := "core",
@@ -331,7 +332,7 @@ val preparePortal = TaskKey[Unit]("preparePortal", "Runs NPM to prepare portal f
 val checkJsHeaders = TaskKey[Unit]("checkJsHeaders", "Runs script to check for APL 2.0 license headers")
 val createJsHeaders = TaskKey[Unit]("createJsHeaders", "Runs script to prepend APL 2.0 license headers to files")
 
-lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, AutomateHeaderPlugin)
+lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, AutomateHeaderPlugin, WebScalaJSBundlerPlugin)
   .settings(sharedSettings)
   .settings(testSettings)
   .settings(portalPublishSettings)
@@ -371,9 +372,24 @@ lazy val portal = (project in file("modules/portal")).enablePlugins(PlayScala, A
     },
 
     // change the name of the output to portal.zip
-    packageName in Universal := "portal"
+    packageName in Universal := "portal",
+
+    scalaJSProjects := Seq(v2client),
+
+    pipelineStages in Assets := Seq(scalaJSPipeline)
   )
   .dependsOn(dynamodb, mysql)
+
+lazy val v2client = (project in file("modules/v2client"))
+  .enablePlugins(AutomateHeaderPlugin, ScalaJSBundlerPlugin)
+  .settings(sharedSettings)
+  .settings(
+    name := "v2client",
+    libraryDependencies ++= portalv2JsDependencies.value,
+    npmDependencies in Compile ++= portalv2NpmDependencies,
+    webpackBundlingMode := BundlingMode.LibraryAndApplication()
+  )
+  .dependsOn(core)
 
 lazy val docSettings = Seq(
   git.remoteRepo := "https://github.com/vinyldns/vinyldns",

--- a/modules/portal/app/controllers/FrontendController.scala
+++ b/modules/portal/app/controllers/FrontendController.scala
@@ -42,6 +42,8 @@ class FrontendController @Inject()(
   implicit lazy val customLinks: CustomLinks = CustomLinks(configuration)
   implicit lazy val meta: Meta = Meta(configuration)
   private val logger = LoggerFactory.getLogger(classOf[FrontendController])
+  private val v2ClientEnabled =
+    configuration.getOptional[Boolean]("v2client.enabled").getOrElse(false)
 
   def loginPage(): Action[AnyContent] = Action { implicit request =>
     request.session.get("username") match {
@@ -66,6 +68,11 @@ class FrontendController @Inject()(
     logger.info(
       s"User account for '${request.session.get("username").getOrElse("username not found")}' is locked.")
     Unauthorized(views.html.noAccess())
+  }
+
+  def clientV2(unusedReactRoute: String): Action[AnyContent] = Action { implicit request =>
+    if (v2ClientEnabled) Ok(views.html.v2client())
+    else Redirect("/")
   }
 
   def index(): Action[AnyContent] = userAction.async { implicit request =>

--- a/modules/portal/app/views/v2client.scala.html
+++ b/modules/portal/app/views/v2client.scala.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="body-full-height">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<link rel="stylesheet" type="text/css" id="theme" href="/public/gentelella/vendors/bootstrap/dist/css/bootstrap.min.css"/>
+		<script src="@routes.Assets.versioned("v2client-fastopt-bundle.js")" type="text/javascript"></script>
+	</head>
+	<body onload="ReactApp.main('root')">
+		<div id="root"></div>
+	</body>
+</html>

--- a/modules/portal/conf/routes
+++ b/modules/portal/conf/routes
@@ -8,6 +8,8 @@ GET           /index                             @controllers.FrontendController
 GET           /login                             @controllers.FrontendController.loginPage
 GET           /logout                            @controllers.FrontendController.logout
 GET           /noaccess                          @controllers.FrontendController.noAccess
+GET			  /v2						         @controllers.FrontendController.clientV2(reactRoute: String = "")
+GET			  /v2/*reactroute					 @controllers.FrontendController.clientV2(reactroute)
 
 GET           /groups                            @controllers.FrontendController.viewAllGroups
 GET           /groups/:gid                       @controllers.FrontendController.viewGroup(gid: String)

--- a/modules/v2client/src/main/scala/vinyldns/v2client/ReactApp.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/ReactApp.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client
+
+import org.scalajs.dom
+import vinyldns.v2client.css.AppCSS
+import vinyldns.v2client.routes.AppRouter
+
+import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+
+@JSExportTopLevel("ReactApp")
+object ReactApp {
+  @JSExport
+  def main(containerId: String): Unit = {
+    AppCSS.load
+    AppRouter.router().renderIntoDOM(dom.document.getElementById(containerId))
+  }
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/components/Footer.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/components/Footer.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.components
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+
+object Footer {
+
+  val component = ScalaComponent.builder
+    .static("Footer")(
+      <.footer(
+        ^.textAlign.center,
+        <.div(^.borderBottom := "1px solid grey", ^.padding := "0px"),
+        <.p(^.paddingTop := "5px", "Footer")
+      )
+    )
+    .build
+
+  def apply(): Unmounted[Unit, Unit, Unit] = component()
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/components/LeftNav.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/components/LeftNav.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.components
+
+import scalacss.ScalaCssReact._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.vdom.html_<^._
+import vinyldns.v2client.models.Menu
+import vinyldns.v2client.routes.AppRouter.AppPage
+
+object LeftNav {
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  object Style extends StyleSheet.Inline {
+
+    import dsl._
+
+    val container = style(
+      listStyle := "none",
+      padding.`0`,
+      borderRight :=! "1px solid rgb(223, 220, 220)"
+    )
+
+    val menuItem = styleF.bool { selected =>
+      styleS(
+        lineHeight(48.px),
+        padding :=! "0 25px",
+        cursor.pointer,
+        textDecoration := "none",
+        mixinIfElse(selected)(color.red, fontWeight._500)(
+          color.black,
+          &.hover(color(c"#555555"), backgroundColor(c"#ecf0f1"))
+        )
+      )
+    }
+  }
+
+  case class Props(menus: Vector[Menu], selectedPage: AppPage, ctrl: RouterCtl[AppPage])
+
+  implicit val currentPageReuse = Reusability.by_==[AppPage]
+  implicit val propsReuse = Reusability.by((_: Props).selectedPage)
+
+  val component = ScalaComponent
+    .builder[Props]("LeftNav")
+    .render_P { P =>
+      <.ul(
+        ^.className := "col-xl-3 col-md-2 col-xs-1",
+        Style.container,
+        P.menus.toTagMod(
+          item =>
+            <.li(
+              ^.key := item.name,
+              Style.menuItem(item.route.getClass == P.selectedPage.getClass),
+              item.name,
+              P.ctrl.setOnClick(item.route))
+        )
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(props: Props): Unmounted[Props, Unit, Unit] = component(props)
+
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/components/TopNav.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/components/TopNav.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.components
+
+import scalacss.ScalaCssReact._
+import vinyldns.v2client.models.Menu
+import vinyldns.v2client.routes.AppRouter.AppPage
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.extra.Reusability
+import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.vdom.html_<^._
+
+object TopNav {
+
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  object Style extends StyleSheet.Inline {
+
+    import dsl._
+
+    val navMenu = style(
+      display.flex,
+      alignItems.center,
+      backgroundColor(c"#F2706D"),
+      margin.`0`,
+      listStyle := "none")
+
+    val menuItem = styleF.bool { selected =>
+      styleS(
+        padding(20.px),
+        fontSize(1.5.em),
+        cursor.pointer,
+        color(c"rgb(244, 233, 233)"),
+        mixinIfElse(selected)(backgroundColor(c"#E8433F"), fontWeight._500)(
+          &.hover(backgroundColor(c"#B6413E")))
+      )
+    }
+  }
+
+  case class Props(menus: Vector[Menu], selectedPage: AppPage, ctrl: RouterCtl[AppPage])
+
+  implicit val currentPageReuse = Reusability.by_==[AppPage]
+  implicit val propsReuse = Reusability.by((_: Props).selectedPage)
+
+  val component = ScalaComponent
+    .builder[Props]("TopNav")
+    .render_P { P =>
+      <.header(
+        <.nav(
+          <.ul(
+            Style.navMenu,
+            P.menus.toTagMod { item =>
+              <.li(
+                ^.key := item.name,
+                Style.menuItem(item.route.getClass == P.selectedPage.getClass),
+                item.name,
+                P.ctrl.setOnClick(item.route)
+              )
+            }
+          )
+        )
+      )
+    }
+    .configure(Reusability.shouldComponentUpdate)
+    .build
+
+  def apply(props: Props): Unmounted[Props, Unit, Unit] = component(props)
+
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/css/AppCSS.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/css/AppCSS.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.css
+
+import scalacss.internal.mutable.GlobalRegistry
+import vinyldns.v2client.components.{LeftNav, TopNav}
+import vinyldns.v2client.pages.{HomePage, OtherPage}
+
+object AppCSS {
+
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  def load: Any = {
+    GlobalRegistry.register(
+      GlobalStyle.styleSheet,
+      TopNav.Style,
+      LeftNav.Style,
+      OtherPage.Style,
+      HomePage.Style)
+    GlobalRegistry.onRegistration(_.addToDocument())
+  }
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/css/GlobalStyle.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/css/GlobalStyle.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.css
+
+object GlobalStyle {
+
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  object styleSheet extends StyleSheet.Inline {
+    import dsl._
+
+    style(
+      unsafeRoot("body")(
+        margin.`0`,
+        padding.`0`,
+        fontSize(14.px)
+      )
+    )
+  }
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/models/Menu.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/models/Menu.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.models
+
+import vinyldns.v2client.routes.AppRouter.AppPage
+
+case class Menu(name: String, route: AppPage)

--- a/modules/v2client/src/main/scala/vinyldns/v2client/pages/HomePage.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/pages/HomePage.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.pages
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import scalacss.ScalaCssReact._
+
+object HomePage {
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  object Style extends StyleSheet.Inline {
+    import dsl._
+    val content = style(textAlign.center, fontSize(30.px), minHeight(450.px), paddingTop(40.px))
+  }
+
+  val component = {
+    ScalaComponent.builder
+      .static("HomePage")(<.div(Style.content, "Scala js react template"))
+      .build
+  }
+
+  def apply(): Unmounted[Unit, Unit, Unit] = component()
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/pages/OtherPage.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/pages/OtherPage.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.pages
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Scala.Unmounted
+import japgolly.scalajs.react.vdom.html_<^._
+import scalacss.ScalaCssReact._
+
+object OtherPage {
+  val CssSettings = scalacss.devOrProdDefaults
+  import CssSettings._
+
+  object Style extends StyleSheet.Inline {
+    import dsl._
+    val content = style(textAlign.center, fontSize(30.px), minHeight(450.px), paddingTop(40.px))
+  }
+
+  val component = {
+    ScalaComponent.builder
+      .static("OtherPage")(<.div(Style.content, "Other"))
+      .build
+  }
+
+  def apply(): Unmounted[Unit, Unit, Unit] = component()
+}

--- a/modules/v2client/src/main/scala/vinyldns/v2client/routes/AppRouter.scala
+++ b/modules/v2client/src/main/scala/vinyldns/v2client/routes/AppRouter.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vinyldns.v2client.routes
+
+import japgolly.scalajs.react.extra.router.{Resolution, RouterConfigDsl, RouterCtl, _}
+import japgolly.scalajs.react.vdom.html_<^._
+import org.scalajs.dom.html.Div
+import vinyldns.v2client.components.{Footer, LeftNav, TopNav}
+import vinyldns.v2client.models.Menu
+import vinyldns.v2client.pages.HomePage
+import vinyldns.v2client.pages.OtherPage
+
+object AppRouter {
+
+  sealed trait AppPage
+
+  case object Home extends AppPage
+  case object Other extends AppPage
+
+  val menu = Vector(
+    Menu("Home", Home),
+    Menu("Other", Other)
+  )
+
+  val config = RouterConfigDsl[AppPage].buildConfig { dsl =>
+    import dsl._
+    (staticRoute("Home", Home) ~> render(HomePage())
+      | staticRoute("Other", Other) ~> render(OtherPage()))
+      .notFound(redirectToPage(Home)(Redirect.Replace))
+      .renderWith(layout)
+  }
+
+  def layout(c: RouterCtl[AppPage], r: Resolution[AppPage]): VdomTagOf[Div] =
+    <.div(
+      TopNav(TopNav.Props(menu, r.page, c)),
+      LeftNav(LeftNav.Props(menu, r.page, c)),
+      r.render(),
+      Footer()
+    )
+
+  val baseUrl = BaseUrl.fromWindowOrigin / "v2/"
+
+  val router = Router(baseUrl, config)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,6 @@
 import sbt._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+
 object Dependencies {
 
   lazy val akkaHttpV = "10.1.5"
@@ -16,6 +18,9 @@ object Dependencies {
   lazy val awsV = "1.11.423"
   lazy val jaxbV = "2.3.0"
   lazy val ip4sV = "1.1.1"
+  lazy val scalaJSReactVersion = "1.3.1"
+  lazy val scalaCssVersion = "0.5.5"
+  lazy val reactJsVersion = "16.5.1"
 
   lazy val apiDependencies = Seq(
     "com.typesafe.akka"         %% "akka-http"                      % akkaHttpV,
@@ -104,5 +109,20 @@ object Dependencies {
     "com.typesafe.play"         %% "play-guice"                     % playV,
     "com.typesafe.play"         %% "play-ahc-ws"                    % playV,
     "com.typesafe.play"         %% "play-specs2"                    % playV % "test"
+  )
+
+  lazy val portalv2JsDependencies = Def.setting(
+    Seq(
+      "org.scala-js" %%% "scalajs-dom" % "0.9.1",
+      "com.github.japgolly.scalajs-react" %%% "core" % scalaJSReactVersion,
+      "com.github.japgolly.scalajs-react" %%% "extra" % scalaJSReactVersion,
+      "com.github.japgolly.scalacss" %%% "core" % scalaCssVersion,
+      "com.github.japgolly.scalacss" %%% "ext-react" % scalaCssVersion
+    )
+  )
+
+  lazy val portalv2NpmDependencies = Seq(
+    "react" -> reactJsVersion,
+    "react-dom" -> reactJsVersion
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -40,3 +40,10 @@ addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.0")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.14.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.14.0")


### PR DESCRIPTION
changing things up a bit to focus on the browser client only

This differs from the `portalv2` branch in that it is not using a new akka http server to host the React app, this branch utilizes the Play server that hosts the existing portal app

A client-v2 route was added to serve the React App 