### PR TITLE
support group search

### DIFF
--- a/modules/client/src/main/scala/vinyldns/client/components/Modal.scala
+++ b/modules/client/src/main/scala/vinyldns/client/components/Modal.scala
@@ -24,7 +24,7 @@ import japgolly.scalajs.react.component.Scala.Unmounted
 import vinyldns.client.css.GlobalStyle
 
 object Modal {
-  case class Props(title: String, close: () => Callback)
+  case class Props(title: String, close: Unit => Callback)
 
   private val component = ScalaComponent
     .builder[Props]("Modal")
@@ -47,7 +47,7 @@ object Modal {
                 <.button(
                   ^.className := "close",
                   ^.`type` := "button",
-                  ^.onClick --> props.close(),
+                  ^.onClick --> props.close(()),
                   <.span("x")
                 ),
                 <.h4(

--- a/modules/client/src/main/scala/vinyldns/client/pages/grouplist/components/CreateGroupModal.scala
+++ b/modules/client/src/main/scala/vinyldns/client/pages/grouplist/components/CreateGroupModal.scala
@@ -28,7 +28,7 @@ import vinyldns.client.components.AlertBox.setNotification
 
 object CreateGroupModal {
   case class State(group: GroupCreateInfo)
-  case class Props(http: Http, close: () => Callback, refreshGroups: () => Callback)
+  case class Props(http: Http, close: Unit => Callback, refreshGroups: Unit => Callback)
 
   val component = ScalaComponent
     .builder[Props]("CreateGroupForm")
@@ -65,7 +65,7 @@ object CreateGroupModal {
                 <.button(
                   ^.`type` := "button",
                   ^.className := "btn btn-default pull-right test-close-create-group",
-                  ^.onClick --> P.close(),
+                  ^.onClick --> P.close(()),
                   "Close"
                 )
               )
@@ -113,8 +113,8 @@ object CreateGroupModal {
           }
           val onSuccess = { (httpResponse: HttpResponse, _: Option[Group]) =>
             setNotification(P.http.toNotification("creating group", httpResponse)) >>
-              P.close() >>
-              P.refreshGroups()
+              P.close(()) >>
+              P.refreshGroups(())
           }
           P.http.post(PostGroupRoute, write(groupWithUserId), onSuccess, onFailure)
         }

--- a/modules/client/src/test/scala/vinyldns/client/pages/grouplist/GroupListPageSpec.scala
+++ b/modules/client/src/test/scala/vinyldns/client/pages/grouplist/GroupListPageSpec.scala
@@ -35,7 +35,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
     val mockHttp = mock[Http]
 
     (mockHttp.get[GroupList] _)
-      .expects(ListGroupsRoute, *, *)
+      .expects(ListGroupsRoute(), *, *)
       .once()
       .onCall { (_, onSuccess, _) =>
         onSuccess.apply(mock[HttpResponse], Some(initialGroupList))
@@ -43,36 +43,6 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
   }
 
   "GroupListPage" should {
-    "get groups when mounting" in new Fixture {
-
-      ReactTestUtils.withRenderedIntoDocument(GroupListPage(ToGroupListPage, mockRouter, mockHttp)) {
-        c =>
-          c.state.groupsList shouldBe Some(initialGroupList)
-      }
-    }
-
-    "update groups when hitting refresh button" in new Fixture {
-      val updatedGroupsList = GroupList(generateGroups(2).toList, Some(100))
-
-      ReactTestUtils.withRenderedIntoDocument(GroupListPage(ToGroupListPage, mockRouter, mockHttp)) {
-        c =>
-          c.state.groupsList shouldBe Some(initialGroupList)
-
-          (mockHttp.get[GroupList] _)
-            .expects(ListGroupsRoute, *, *)
-            .once()
-            .onCall { (_, onSuccess, _) =>
-              onSuccess.apply(mock[HttpResponse], Some(updatedGroupsList))
-            }
-
-          val refreshButton =
-            ReactTestUtils.findRenderedDOMComponentWithClass(c, "test-refresh-groups")
-          Simulate.click(refreshButton)
-
-          c.state.groupsList shouldBe Some(updatedGroupsList)
-      }
-    }
-
     "show create group modal when clicking create group button" in new Fixture {
 
       ReactTestUtils.withRenderedIntoDocument(GroupListPage(ToGroupListPage, mockRouter, mockHttp)) {

--- a/modules/client/src/test/scala/vinyldns/client/pages/grouplist/components/CreateGroupModalSpec.scala
+++ b/modules/client/src/test/scala/vinyldns/client/pages/grouplist/components/CreateGroupModalSpec.scala
@@ -32,13 +32,12 @@ class CreateGroupModalSpec extends WordSpec with Matchers with MockFactory with 
   "CreateGroupModal" should {
     "not call withConfirmation if submitted without required fields" in {
       val mockHttp = mock[Http]
-      val mockClose = mock[() => Callback]
-      val mockRefresh = mock[() => Callback]
 
       (mockHttp.withConfirmation _).expects(*, *).never()
       (mockHttp.post _).expects(*, *, *, *).never()
 
-      val props = CreateGroupModal.Props(mockHttp, mockClose, mockRefresh)
+      val props =
+        CreateGroupModal.Props(mockHttp, generateNoOpHandler[Unit], generateNoOpHandler[Unit])
       ReactTestUtils.withRenderedIntoDocument(CreateGroupModal(props)) { c =>
         val form =
           ReactTestUtils.findRenderedDOMComponentWithClass(c, "test-create-group-form")
@@ -48,13 +47,12 @@ class CreateGroupModalSpec extends WordSpec with Matchers with MockFactory with 
 
     "call withConfirmation if submitting with required fields" in {
       val mockHttp = mock[Http]
-      val mockClose = mock[() => Callback]
-      val mockRefresh = mock[() => Callback]
 
       (mockHttp.withConfirmation _).expects(*, *).once().returns(Callback.empty)
       (mockHttp.post _).expects(*, *, *, *).never()
 
-      val props = CreateGroupModal.Props(mockHttp, mockClose, mockRefresh)
+      val props =
+        CreateGroupModal.Props(mockHttp, generateNoOpHandler[Unit], generateNoOpHandler[Unit])
       ReactTestUtils.withRenderedIntoDocument(CreateGroupModal(props)) { c =>
         val nameField =
           ReactTestUtils.findRenderedDOMComponentWithClass(c, "test-name")
@@ -71,8 +69,6 @@ class CreateGroupModalSpec extends WordSpec with Matchers with MockFactory with 
 
     "call http.post if submitting with required fields and confirming" in {
       val mockHttp = mock[Http]
-      val mockClose = mock[() => Callback]
-      val mockRefresh = mock[() => Callback]
 
       val testGroup =
         GroupCreateInfo("test-name", "test@email.com", Seq(Id(testUser.id)), Seq(Id(testUser.id)))
@@ -84,7 +80,8 @@ class CreateGroupModalSpec extends WordSpec with Matchers with MockFactory with 
         .once()
         .returns(Callback.empty)
 
-      val props = CreateGroupModal.Props(mockHttp, mockClose, mockRefresh)
+      val props =
+        CreateGroupModal.Props(mockHttp, generateNoOpHandler[Unit], generateNoOpHandler[Unit])
       ReactTestUtils.withRenderedIntoDocument(CreateGroupModal(props)) { c =>
         val nameField =
           ReactTestUtils.findRenderedDOMComponentWithClass(c, "test-name")


### PR DESCRIPTION
ended up moving the logic for listing groups into the table itself. avoided this before because the css was easier to make look good when the parent page owned the refresh and search button, but passing those values as props to the table component would have made re-rerending ugly since theyd want to refresh the list every time someone enters a search character 