### PR TITLE
Items per page

### DIFF
--- a/modules/client/src/main/scala/vinyldns/client/css/GlobalStyle.scala
+++ b/modules/client/src/main/scala/vinyldns/client/css/GlobalStyle.scala
@@ -47,6 +47,8 @@ object GlobalStyle {
 
     val overflow = style(overflowY.scroll)
 
+    val keepWhitespace = style(whiteSpace.pre)
+
     val noop = style()
   }
 }

--- a/modules/client/src/main/scala/vinyldns/client/http/RequestRoute.scala
+++ b/modules/client/src/main/scala/vinyldns/client/http/RequestRoute.scala
@@ -50,7 +50,7 @@ final case class ListGroupsRoute(
   val queryStrings =
     Map.empty[String, String] ++
       Map("maxItems" -> maxItems.toString) ++
-      nameFilter.map(f => "nameFilter" -> f) ++
+      nameFilter.map(f => "groupNameFilter" -> f) ++
       startFrom.map(s => "startFrom" -> s)
 
   def path: String = s"/api/groups${toQueryString(queryStrings)}"


### PR DESCRIPTION
allow the user to select how many items are on a page. Makes sanity testing paging easier 