### PR TITLE
get 1000 groups for everywhere other than groups table

### DIFF
--- a/modules/client/src/main/scala/vinyldns/client/http/RequestRoute.scala
+++ b/modules/client/src/main/scala/vinyldns/client/http/RequestRoute.scala
@@ -77,7 +77,7 @@ object RegenerateCredentialsRoute extends RequestRoute[Unit] {
 }
 
 final case class ListGroupsRoute(
-    maxItems: Int = 100,
+    maxItems: Int = 1000,
     nameFilter: Option[String] = None,
     startFrom: Option[String] = None)
     extends RequestRoute[GroupListResponse] {

--- a/modules/client/src/main/scala/vinyldns/client/pages/batch/create/BatchChangeCreatePage.scala
+++ b/modules/client/src/main/scala/vinyldns/client/pages/batch/create/BatchChangeCreatePage.scala
@@ -571,7 +571,7 @@ object BatchChangeCreatePage extends PropsFromAppRouter {
       val onFailure = { httpResponse: HttpResponse =>
         addNotification(P.http.toNotification("listing groups", httpResponse, onlyOnError = true))
       }
-      P.http.get(ListGroupsRoute(), onSuccess, onFailure)
+      P.http.get(ListGroupsRoute(1000), onSuccess, onFailure)
     }
 
   }

--- a/modules/client/src/main/scala/vinyldns/client/pages/zone/list/ZoneListPage.scala
+++ b/modules/client/src/main/scala/vinyldns/client/pages/zone/list/ZoneListPage.scala
@@ -208,7 +208,7 @@ object ZoneListPage extends PropsFromAppRouter {
       val onFailure = { httpResponse: HttpResponse =>
         addNotification(P.http.toNotification("listing groups", httpResponse, onlyOnError = true))
       }
-      P.http.get(ListGroupsRoute(), onSuccess, onFailure)
+      P.http.get(ListGroupsRoute(1000), onSuccess, onFailure)
     }
 
     def getBackendIds(P: Props): Callback = {

--- a/modules/client/src/main/scala/vinyldns/client/pages/zone/view/ZoneViewPage.scala
+++ b/modules/client/src/main/scala/vinyldns/client/pages/zone/view/ZoneViewPage.scala
@@ -241,7 +241,7 @@ object ZoneViewPage extends PropsFromAppRouter {
         bs.modState(_.copy(groupList = parsed))
       }
 
-      P.http.get(ListGroupsRoute(100), onSuccess, onFailure)
+      P.http.get(ListGroupsRoute(1000), onSuccess, onFailure)
     }
 
     def getBackendIds(P: Props): Callback = {

--- a/modules/client/src/test/scala/vinyldns/client/pages/group/list/GroupListPageSpec.scala
+++ b/modules/client/src/test/scala/vinyldns/client/pages/group/list/GroupListPageSpec.scala
@@ -36,7 +36,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
     val mockHttp = mock[Http]
 
     (mockHttp.get[GroupListResponse] _)
-      .expects(ListGroupsRoute(), *, *)
+      .expects(ListGroupsRoute(100), *, *)
       .once()
       .onCall { (_, onSuccess, _) =>
         onSuccess.apply(mock[HttpResponse], Some(initialGroupList))
@@ -81,7 +81,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
 
     "call http.get with groupNameFilter when someone uses search bar" in new Fixture {
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(nameFilter = Some("filter")), *, *)
+        .expects(ListGroupsRoute(100, nameFilter = Some("filter")), *, *)
         .once()
         .returns(Callback.empty)
 
@@ -100,7 +100,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
       val groupListWithNext = initialGroupList.copy(nextId = Some("next"))
 
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(), *, *)
+        .expects(ListGroupsRoute(100), *, *)
         .once()
         .onCall { (_, onSuccess, _) =>
           onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))
@@ -109,7 +109,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
       ReactTestUtils.withRenderedIntoDocument(GroupListPage(ToGroupListPage, mockRouter, mockHttp)) {
         c =>
           (mockHttp.get[GroupListResponse] _)
-            .expects(ListGroupsRoute(startFrom = Some("next")), *, *)
+            .expects(ListGroupsRoute(100, startFrom = Some("next")), *, *)
             .once()
             .onCall { (_, onSuccess, _) =>
               onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))
@@ -122,7 +122,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
           next.outerHtmlScrubbed() should include("Page 3")
 
           (mockHttp.get[GroupListResponse] _)
-            .expects(ListGroupsRoute(), *, *)
+            .expects(ListGroupsRoute(100), *, *)
             .once()
             .onCall { (_, onSuccess, _) =>
               onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))
@@ -137,7 +137,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
 
     "call http.get with groupNameFilter when someone uses refresh button" in new Fixture {
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(nameFilter = Some("filter")), *, *)
+        .expects(ListGroupsRoute(100, nameFilter = Some("filter")), *, *)
         .once()
         .returns(Callback.empty)
 
@@ -157,7 +157,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
       val groupListWithNext = initialGroupList.copy(nextId = Some("next"))
 
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(), *, *)
+        .expects(ListGroupsRoute(100), *, *)
         .once()
         .onCall { (_, onSuccess, _) =>
           onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))
@@ -166,7 +166,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
       ReactTestUtils.withRenderedIntoDocument(GroupListPage(ToGroupListPage, mockRouter, mockHttp)) {
         c =>
           (mockHttp.get[GroupListResponse] _)
-            .expects(ListGroupsRoute(startFrom = Some("next")), *, *)
+            .expects(ListGroupsRoute(100, startFrom = Some("next")), *, *)
             .once()
             .onCall { (_, onSuccess, _) =>
               onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))
@@ -179,7 +179,7 @@ class GroupListPageSpec extends WordSpec with Matchers with MockFactory with Sha
           next.outerHtmlScrubbed() should include("Page 3")
 
           (mockHttp.get[GroupListResponse] _)
-            .expects(ListGroupsRoute(), *, *)
+            .expects(ListGroupsRoute(100), *, *)
             .once()
             .onCall { (_, onSuccess, _) =>
               onSuccess.apply(mock[HttpResponse], Some(groupListWithNext))

--- a/modules/client/src/test/scala/vinyldns/client/pages/group/list/components/GroupsTableSpec.scala
+++ b/modules/client/src/test/scala/vinyldns/client/pages/group/list/components/GroupsTableSpec.scala
@@ -36,7 +36,7 @@ class GroupsTableSpec extends WordSpec with Matchers with MockFactory with Share
     val mockHttp = mock[Http]
 
     (mockHttp.get[GroupListResponse] _)
-      .expects(ListGroupsRoute(), *, *)
+      .expects(ListGroupsRoute(100), *, *)
       .once()
       .onCall { (_, onSuccess, _) =>
         onSuccess.apply(mock[HttpResponse], Some(initialGroupList))
@@ -57,7 +57,7 @@ class GroupsTableSpec extends WordSpec with Matchers with MockFactory with Share
       val mockHttp = mock[Http]
 
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(), *, *)
+        .expects(ListGroupsRoute(100), *, *)
         .once()
         .onCall { (_, onSuccess, _) =>
           onSuccess.apply(mock[HttpResponse], None)
@@ -75,7 +75,7 @@ class GroupsTableSpec extends WordSpec with Matchers with MockFactory with Share
       val mockHttp = mock[Http]
 
       (mockHttp.get[GroupListResponse] _)
-        .expects(ListGroupsRoute(), *, *)
+        .expects(ListGroupsRoute(100), *, *)
         .once()
         .onCall { (_, onSuccess, _) =>
           onSuccess.apply(mock[HttpResponse], Some(GroupListResponse(List(), 100)))


### PR DESCRIPTION
support users need the max number of groups for their forms 