### PR TITLE
make travis sudo to give it more mem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 python:
   - 2.7
 
-sudo: false
+sudo: true
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Upon researching the java out of mem error, one possible solution is to make travis sudo since it gives it larger vm. It appears our .jvmopts may be hitting their limit on the travis vm 